### PR TITLE
notes et évènements non accessibles depuis le menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,7 +5,10 @@
 
 - title: Articles
   url: /articles/
-
+  
+- title: Notes
+  url: /notes/
+  
 - title: Ateliers d'Ada
   url: /AteliersdAda/ 
 


### PR DESCRIPTION
les notes (ex : Bricodeurs recrutent animateurs , veille...) ne sont pas accessibles depuis le menu 
l'evenements Nuit du Code Citoyen non plus --> faire un lien vers les évènements ? http://lesbricodeurs.fr/evenements/  ou directement vers http://lesbricodeurs.fr/evenements/NuitCodeCitoyen/